### PR TITLE
replaced random_shuffle() by shuffle()

### DIFF
--- a/src/bboard/environment.cpp
+++ b/src/bboard/environment.cpp
@@ -2,6 +2,7 @@
 #include <chrono>
 #include <functional>
 #include <algorithm>
+#include <random>
 
 #include "bboard.hpp"
 
@@ -55,9 +56,11 @@ void Environment::MakeGame(std::array<Agent*, AGENT_COUNT> a, bool random)
     bboard::InitBoardItems(*state.get());
 
     std::array<int, 4> f = {0, 1, 2, 3};
+
     if(random)
     {
-        std::random_shuffle(std::begin(f), std::end(f));
+        auto seed = std::chrono::high_resolution_clock::now().time_since_epoch().count();
+        std::shuffle(f.begin(), f.end(), std::default_random_engine(seed));
     }
     state->PutAgentsInCorners(f[0], f[1], f[2], f[3]);
 


### PR DESCRIPTION
Hi @tomatenbrei ,

I needed to replace `std::random_shuffle()` by `std::shuffle()` because `std::shuffle()` was deprecated in C++14 and removed in C++17.
* https://en.cppreference.com/w/cpp/algorithm/random_shuffle
